### PR TITLE
Fix os.difftime bug in profiler.lua

### DIFF
--- a/Chapter05/profiler.lua
+++ b/Chapter05/profiler.lua
@@ -38,14 +38,14 @@ profiler.private_hook = function(event)
 		profiler.names[f] = info.name
 		profiler.counts[f] = 1
 		profiler.times[f] = 0.0
-		profiler.timers[f] = os.clock()
+		profiler.timers[f] = os.time()
 	elseif profiler.names[f] ~= nil then
 		if event == "call" then
 			profiler.counts[f] = profiler.counts[f] + 1
-			profiler.timers[f] = os.clock()
+			profiler.timers[f] = os.time()
 		elseif event == "return" then
 			local t = profiler.times[f];
-			local d = os.difftime(profiler.timers[f],os.clock())
+			local d = os.difftime(profiler.timers[f],os.time())
 			profiler.times[f] = t + d
 		end
 	end


### PR DESCRIPTION
According to Lua's manual, os.difftime uses values from os.time instead of
os.clock.